### PR TITLE
TMS-1092: Move page heading from over hero image to content area & remove hero overlay

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1092: Move page heading from over hero image to content area & remove hero overlay
+
 ## [1.15.1] - 2024-09-25
 
 - TMS-1067: Show price-info for event in listing if it's free

--- a/partials/page.dust
+++ b/partials/page.dust
@@ -1,0 +1,48 @@
+{>"shared/base" /}
+
+{<content}
+    <main class="main-content" id="main-content">
+        {?Page.hero_image}
+            {>"views/page/page-hero" /}
+        {/Page.hero_image}
+
+        {?Header.breadcrumbs}
+            <div class="breadcrumbs-container section pt-6 pb-7">
+                <div class="container">
+                    <div class="columns">
+                        <div class="column">
+                            {>"ui/breadcrumbs" breadcrumbs=Header.breadcrumbs /}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {/Header.breadcrumbs}
+
+        <section class="page__hero-heading section pt-5-desktop pt-0 pb-0">
+            {>"ui/entry-title" class="mt-0 has-text-centered is-uppercase" /}
+        </section>
+
+        <section class="section {?Header.hero_image}pt-7{:else}{?Header.breadcrumbs}pt-0{:else}pt-10{/Header.breadcrumbs}{/Header.hero_image}">
+            <div class="container">
+                <div class="columns">
+                    <div class="column is-12">
+                        <article class="entry">
+                             {>"ui/entry-title" class="mt-0 has-text-centered" hero_image=Page.hero_image /}
+                            <div class="entry__content is-content-grid keep-vertical-spacing">
+                                {@content /}
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        {>"ui/components" components=Page.components /}
+    </main>
+
+    {#Page}
+        {?post_siblings}
+            {>"ui/sibling-navigation" /}
+        {/post_siblings}
+    {/Page}
+{/content}

--- a/partials/page.dust
+++ b/partials/page.dust
@@ -18,10 +18,6 @@
             </div>
         {/Header.breadcrumbs}
 
-        <section class="page__hero-heading section pt-5-desktop pt-0 pb-0">
-            {>"ui/entry-title" class="mt-0 has-text-centered is-uppercase" /}
-        </section>
-
         <section class="section {?Header.hero_image}pt-7{:else}{?Header.breadcrumbs}pt-0{:else}pt-10{/Header.breadcrumbs}{/Header.hero_image}">
             <div class="container">
                 <div class="columns">

--- a/partials/ui/entry-title.dust
+++ b/partials/ui/entry-title.dust
@@ -1,5 +1,3 @@
-{^hero_image}
-    <h1 class="entry__title {?class} {class}{/class}">
-        {@title /}
-    </h1>
-{/hero_image}
+<h1 class="entry__title {?class} {class}{/class}">
+    {@title /}
+</h1>

--- a/partials/views/page/page-hero.dust
+++ b/partials/views/page/page-hero.dust
@@ -1,15 +1,1 @@
-<section class="page__hero section is-relative pt-0 pb-0 has-background-cover" {@inlinebg id=Page.hero_image size="fullhd" /}>
-    {?Page.use_overlay}
-        <div class="overlay overlay--dark-50"></div>
-    {/Page.use_overlay}
-
-    <div class="is-absolute has-bottom-2 has-right-0 has-left-0 ">
-        <div class="container">
-            <div class="columns">
-                <div class="column is-8 is-offset-2">
-                    {>"ui/entry-title" class="mt-0 has-text-centered has-text-white mb-0 is-uppercase" /}
-                </div>
-            </div>
-        </div>
-    </div>
-</section>
+<section class="page__hero section is-relative pt-0 pb-0 has-background-cover" {@inlinebg id=Page.hero_image size="fullhd" /}></section>


### PR DESCRIPTION
Severa-ID: 2129
Severa-kuvaus: TMS-1092 Artikkelikuvista automaattinen tummennus pois
Task: https://hiondigital.atlassian.net/browse/TMS-1092

## Description
- Remove hero-overlay
- Move page heading below hero

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
