### PR TITLE
TMS-1141: Remove page block-section bottom-padding and add padding for last block

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1141: Remove page block-section bottom-padding and add padding for last block
+
 ## [1.16.0] - 2025-04-09
 
 - TMS-1129: Remove menu dropdown parent link

--- a/assets/styles/views/_page.scss
+++ b/assets/styles/views/_page.scss
@@ -8,4 +8,12 @@
             height: 26rem;
         }
     }
+
+    .entry {
+        &__content {
+            > *:last-child {
+                padding-bottom: $theme-spacing-three;
+            }
+        }
+    }
 }

--- a/partials/page.dust
+++ b/partials/page.dust
@@ -18,12 +18,12 @@
             </div>
         {/Header.breadcrumbs}
 
-        <section class="section {?Header.hero_image}pt-7{:else}{?Header.breadcrumbs}pt-0{:else}pt-10{/Header.breadcrumbs}{/Header.hero_image}">
+        <section class="section pb-0 {?Header.hero_image}pt-7{:else}{?Header.breadcrumbs}pt-0{:else}pt-10{/Header.breadcrumbs}{/Header.hero_image}">
             <div class="container">
                 <div class="columns">
                     <div class="column is-12">
                         <article class="entry">
-                             {>"ui/entry-title" class="mt-0 has-text-centered" hero_image=Page.hero_image /}
+                            {>"ui/entry-title" class="mt-0 has-text-centered mb-7-desktop" hero_image=Page.hero_image /}
                             <div class="entry__content is-content-grid keep-vertical-spacing">
                                 {@content /}
                             </div>


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1141 Tampere Filharmonian sivut, tyhjää tilaa Tämän sivun alasivut -komponentin yllä
Task: https://hiondigital.atlassian.net/browse/TMS-1141

<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove page block-section bottom-padding and add padding for last block.
This reduces the empty space between page heading & the first component if there are no blocks used.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
